### PR TITLE
Update Neverball for OMV 6.0

### DIFF
--- a/neverball.spec
+++ b/neverball.spec
@@ -10,14 +10,12 @@ Group:		Games/Arcade
 Url:		https://icculus.org/neverball/
 Source0:	http://icculus.org/neverball/%{name}-%{version}.tar.gz
 BuildRequires:	jpeg-devel
-BuildRequires:	pkgconfig(physfs)
+BuildRequires:	physfs-devel
 BuildRequires:	pkgconfig(gl)
 BuildRequires:	pkgconfig(libpng)
 BuildRequires:	pkgconfig(sdl2)
 BuildRequires:	pkgconfig(SDL2_ttf)
 BuildRequires:	pkgconfig(vorbisfile)
-BuildRequires:	gcc
-BuildRequires:	gcc-c++
 
 %description
 Tilt the floor to roll the ball through the obstacle course before time
@@ -44,11 +42,9 @@ or greater) is required.
 #----------------------------------------------------------------------------
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
-export CC=gcc
-export CXX=g++
 %make_build \
 	CFLAGS="%{optflags}" \
 	CXXFLAGS="%{optflags}" \

--- a/neverball.spec
+++ b/neverball.spec
@@ -16,8 +16,8 @@ BuildRequires:	pkgconfig(libpng)
 BuildRequires:	pkgconfig(sdl2)
 BuildRequires:	pkgconfig(SDL2_ttf)
 BuildRequires:	pkgconfig(vorbisfile)
-BuildRequires:	pkgconfig(gcc)
-BuildRequires:	pkgconfig(gcc-c++)
+BuildRequires:	gcc
+BuildRequires:	gcc-c++
 
 %description
 Tilt the floor to roll the ball through the obstacle course before time

--- a/neverball.spec
+++ b/neverball.spec
@@ -49,7 +49,7 @@ or greater) is required.
 %build
 export CC=gcc
 export CXX=g++
-%make \
+%make_build \
 	CFLAGS="%{optflags}" \
 	CXXFLAGS="%{optflags}" \
 	ENABLE_NLS=1 \

--- a/neverball.spec
+++ b/neverball.spec
@@ -48,7 +48,7 @@ or greater) is required.
 
 %build
 export CC=gcc
-expor CXX=g++
+export CXX=g++
 %make \
 	CFLAGS="%{optflags}" \
 	CXXFLAGS="%{optflags}" \

--- a/neverball.spec
+++ b/neverball.spec
@@ -9,6 +9,7 @@ License:	GPLv2+
 Group:		Games/Arcade
 Url:		https://icculus.org/neverball/
 Source0:	http://icculus.org/neverball/%{name}-%{version}.tar.gz
+BuildRequires:	gettext
 BuildRequires:	jpeg-devel
 BuildRequires:	physfs-devel
 BuildRequires:	pkgconfig(gl)

--- a/neverball.spec
+++ b/neverball.spec
@@ -46,7 +46,7 @@ or greater) is required.
 %autosetup -p1
 
 %build
-make \
+%make_build \
 	CFLAGS="%{optflags}" \
 	CXXFLAGS="%{optflags}" \
 	ENABLE_NLS=1 \

--- a/neverball.spec
+++ b/neverball.spec
@@ -16,6 +16,8 @@ BuildRequires:	pkgconfig(libpng)
 BuildRequires:	pkgconfig(sdl2)
 BuildRequires:	pkgconfig(SDL2_ttf)
 BuildRequires:	pkgconfig(vorbisfile)
+BuildRequires:	pkgconfig(gcc)
+BuildRequires:	pkgconfig(gcc-c++)
 
 %description
 Tilt the floor to roll the ball through the obstacle course before time
@@ -45,6 +47,8 @@ or greater) is required.
 %setup -q
 
 %build
+export CC=gcc
+expor CXX=g++
 %make \
 	CFLAGS="%{optflags}" \
 	CXXFLAGS="%{optflags}" \

--- a/neverball.spec
+++ b/neverball.spec
@@ -45,7 +45,7 @@ or greater) is required.
 %autosetup -p1
 
 %build
-%make_build \
+make \
 	CFLAGS="%{optflags}" \
 	CXXFLAGS="%{optflags}" \
 	ENABLE_NLS=1 \


### PR DESCRIPTION
This change fixes the spec and makes the package buildable on ABF again.